### PR TITLE
Only load the plugin config if it exist on config file

### DIFF
--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -32,10 +32,10 @@ class EditorPlugin(plugin.URLHandler):
         self.match = self.match.decode('string_escape')
 
     def check_config(self):
-        try:
-            saved_config = self.config.plugin_get_config(self.plugin_name)
+        saved_config = self.config.plugin_get_config(self.plugin_name)
+        if saved_config != None:
             config.update(saved_config)
-        except TypeError:
+        else:
             config = {
                 'command': DEFAULT_COMMAND,
                 'match': DEFAULT_REGEX,

--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -32,14 +32,16 @@ class EditorPlugin(plugin.URLHandler):
         self.match = self.match.decode('string_escape')
 
     def check_config(self):
-        config = {
-            'command': DEFAULT_COMMAND,
-            'match': DEFAULT_REGEX,
-        }
-        saved_config = self.config.plugin_get_config(self.plugin_name)
-        config.update(saved_config)
-        self.config.plugin_set_config(self.plugin_name, config)
-        self.config.save()
+        try:
+            saved_config = self.config.plugin_get_config(self.plugin_name)
+            config.update(saved_config)
+        except TypeError:
+            config = {
+                'command': DEFAULT_COMMAND,
+                'match': DEFAULT_REGEX,
+            }
+            self.config.plugin_set_config(self.plugin_name, config)
+            self.config.save()
 
     def get_cwd(self):
         """ Return current working directory. """

--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -32,16 +32,15 @@ class EditorPlugin(plugin.URLHandler):
         self.match = self.match.decode('string_escape')
 
     def check_config(self):
+        config = {
+            'command': DEFAULT_COMMAND,
+            'match': DEFAULT_REGEX,
+        }
         saved_config = self.config.plugin_get_config(self.plugin_name)
         if saved_config != None:
             config.update(saved_config)
-        else:
-            config = {
-                'command': DEFAULT_COMMAND,
-                'match': DEFAULT_REGEX,
-            }
-            self.config.plugin_set_config(self.plugin_name, config)
-            self.config.save()
+        self.config.plugin_set_config(self.plugin_name, config)
+        self.config.save()
 
     def get_cwd(self):
         """ Return current working directory. """


### PR DESCRIPTION
After copy the plugin script to the terminator plugins dir and try to enable it, I get a "TypeError: 'NoneType' object is not iterable" error. This occurs because I do not have the configuration for the plugin on the config file and the script try to load it any way.