### PR TITLE
Add create plugin folder on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ See the demo at https://github.com/mchelem/terminator-editor-plugin/wiki.
 
 
 ### Installing the Plugin ###
-* Copy the plugin file to `~/.config/terminator/plugins`.
+* Create the plugins folder if it doesn't exist. On linux: `mkdir -p ~/.config/terminator/plugins`
+* Copy the plugin file to the plugins folder.
 * In Terminator go to Preferences >> Plugins and enable EditorPlugin.
 * Restart Terminator.
 


### PR DESCRIPTION
This patch adds the instruction on readme to create a plugin folder in
case it don't exist.