### PR TITLE
Added file lookup in library path

### DIFF
--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -77,6 +77,12 @@ class EditorPlugin(plugin.URLHandler):
                 filepath = os.path.join(self.get_cwd(), group_value)
                 if not os.path.exists(filepath):
                     filepath = None
+                    filename = group_value.split('/')[-1]
+                    for r, d, f in os.walk(os.path.expanduser(self.config.plugin_get(self.plugin_name, 'libdir'))):
+                        for file in f:
+                            if filename == file:
+                                filepath = os.path.join(r, file)
+                                break
             elif group_name == 'line':
                 line = group_value
             elif group_name == 'column':


### PR DESCRIPTION
I have a project with a quite complicated Makefile and multiple libraries which the Makefile builds. Unfortunately those printouts doesn't give me the complete filepath. I added a libdir option which looks for the file in my libraries if it doesn't find the file in my main project folder.