### PR TITLE
Support terminator v2

### DIFF
--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -112,6 +112,6 @@ class EditorPlugin(plugin.URLHandler):
                 if self.config.plugin_get(self.plugin_name, 'open_in_current_term'):
                     self.get_terminal().feed(command + '\n')
                 else:
-                    subprocess.call(shlex.split(command))
+                    subprocess.Popen(shlex.split(command))
                 return '--version'
             return command

--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -110,7 +110,7 @@ class EditorPlugin(plugin.URLHandler):
             command = command.replace('{column}', column)
             if self.open_url():
                 if self.config.plugin_get(self.plugin_name, 'open_in_current_term'):
-                    self.get_terminal().feed((command + '\n').encode())
+                    self.get_terminal().vte.feed_child((command+'\n').encode())
                 else:
                     subprocess.Popen(shlex.split(command))
                 return '--version'

--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -110,7 +110,7 @@ class EditorPlugin(plugin.URLHandler):
             command = command.replace('{column}', column)
             if self.open_url():
                 if self.config.plugin_get(self.plugin_name, 'open_in_current_term'):
-                    self.get_terminal().feed(command + '\n')
+                    self.get_terminal().feed((command + '\n').encode())
                 else:
                     subprocess.Popen(shlex.split(command))
                 return '--version'


### PR DESCRIPTION
It's a great plugin.

but those days seems not compatible with terminator 2.x
- open_in_current_term=True: 
  - <=2.1.2: .feed() need bytes
  - \>=2.1.3: .feed() need str
  
- open_in_current_term=False: 
 new editor will stuck terminator window


so, I made little adjust for working with terminator 2.x 

Tested on ubuntu 22 lts, 
- terminator 2.1.1 (with python3.10)
- terminator 2.1.3 (master branch, unreleased now) (with python3.10)
