### PR TITLE
Support for git diff output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,20 @@ See the demo at https://github.com/mchelem/terminator-editor-plugin/wiki.
 
 ### Using the Plugin ###
 - Use the grep command (e.g. <code>grep -rn import *.py</code>)
+- Use `git diff` to see changes with clickable file paths
 - Use &lt;ctrl&gt;+click to open the file.
 - Right click to copy the link.
+
+#### Git Diff Support
+The plugin automatically detects git diff output (enabled by default):
+- Click on `--- a/path` or `+++ b/path` lines to open files
+- Click on `@@ -x,y +a,b @@` hunk headers to open files at specific lines
+- File context is tracked across diff sections for accurate line numbers
+
+To disable git diff support:
+```
+git_diff_support = False
+```
 
 
 ### Configuration ###
@@ -28,7 +40,7 @@ examples are below:
 
     command = gedit +{line} {filepath}
 
-    command = sublime {filepath}:{line}
+    command = subl {filepath}:{line}
 
     command = emacsclient -n +{line} {filepath}
 

--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -112,6 +112,6 @@ class EditorPlugin(plugin.URLHandler):
                 if self.config.plugin_get(self.plugin_name, 'open_in_current_term'):
                     self.get_terminal().feed(command + '\n')
                 else:
-                    subprocess.call(shlex.split(command))
+                    subprocess.Popen(shlex.split(command))
                 return '--version'
             return command

--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -110,7 +110,7 @@ class EditorPlugin(plugin.URLHandler):
             command = command.replace('{column}', column)
             if self.open_url():
                 if self.config.plugin_get(self.plugin_name, 'open_in_current_term'):
-                    self.get_terminal().feed((command + '\n').encode())
+                    self.get_terminal().vte.feed_child((command+'\n').encode())
                 else:
                     subprocess.Popen(shlex.split(command))
                 return '--version'

--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -110,7 +110,7 @@ class EditorPlugin(plugin.URLHandler):
             command = command.replace('{column}', column)
             if self.open_url():
                 if self.config.plugin_get(self.plugin_name, 'open_in_current_term'):
-                    self.get_terminal().feed(command + '\n')
+                    self.get_terminal().feed((command + '\n').encode())
                 else:
                     subprocess.Popen(shlex.split(command))
                 return '--version'

--- a/editor_plugin.py
+++ b/editor_plugin.py
@@ -14,10 +14,17 @@ from terminatorlib import plugin, config
 
 AVAILABLE = ['EditorPlugin']
 
+# Global state to track git diff context
+_git_diff_context = {'file': None, 'line': None}
+
 DEFAULT_COMMAND = 'gvim --remote-silent +{line} {filepath}'
-DEFAULT_REGEX = r'([^ \t\n\r\f\v:]+?):([0-9]+)'
-DEFAULT_GROUPS = 'file line'
+# Basic regex for file paths with line numbers (used when git_diff_support is disabled)
+DEFAULT_REGEX = r'(?:^|(?<= ))(?![ab]/)([a-zA-Z0-9_/.\-]+\.[a-zA-Z0-9]+)(:[0-9]+)?(:[0-9]+)?(?=$|[ \t])'
+# Extended regex including git diff patterns (used when git_diff_support is enabled)
+GIT_DIFF_REGEX = r'(?<=--- a/)[^ \t\n]+|(?<=\+\+\+ b/)[^ \t\n]+|(?<=diff --git a/)[^ \t\n]+|@@ [^@]+ @@|' + DEFAULT_REGEX
+DEFAULT_GROUPS = 'file line column'
 DEFAULT_OPEN_IN_CURRENT_TERM = False
+DEFAULT_GIT_DIFF_SUPPORT = True
 
 def to_bool(val):
     return val == "True"
@@ -43,11 +50,18 @@ class EditorPlugin(plugin.URLHandler):
             'match': DEFAULT_REGEX,
             'groups': DEFAULT_GROUPS,
             'open_in_current_term': DEFAULT_OPEN_IN_CURRENT_TERM,
+            'git_diff_support': DEFAULT_GIT_DIFF_SUPPORT,
         }
         saved_config = self.config.plugin_get_config(self.plugin_name)
         if saved_config is not None:
             config.update(saved_config)
         config["open_in_current_term"] = to_bool(config["open_in_current_term"])
+        config["git_diff_support"] = to_bool(config.get("git_diff_support", DEFAULT_GIT_DIFF_SUPPORT))
+        
+        # Update regex based on git_diff_support setting
+        if config["git_diff_support"]:
+            config['match'] = GIT_DIFF_REGEX
+        
         self.config.plugin_set_config(self.plugin_name, config)
         self.config.save()
 
@@ -72,6 +86,25 @@ class EditorPlugin(plugin.URLHandler):
         # the command, we need to climb the stack to see how we got here.
         return inspect.stack()[3][3] == 'open_url'
 
+    def update_git_diff_context(self, strmatch):
+        """ Update global context when we see git diff headers or hunk markers """
+        global _git_diff_context
+
+        # Check if this is a filename match (from lookbehind patterns)
+        # These won't have the --- or +++ prefix since lookbehind excludes them
+        # We identify them by checking if they look like file paths (contain / or .)
+        if ('/' in strmatch or '.' in strmatch) and not strmatch.startswith('@@'):
+            # This is likely a file path from git diff header
+            _git_diff_context['file'] = strmatch
+            _git_diff_context['line'] = None
+            return
+
+        # Check for hunk header: @@ -71,7 +71,7 @@
+        hunk_match = re.search(r'@@ -\d+,?\d* \+(\d+)', strmatch)
+        if hunk_match:
+            _git_diff_context['line'] = hunk_match.group(1)
+            return
+
     def search_filepath_in_libdir(self, group_value):
         filename = group_value.split('/')[-1]
         libdir = self.config.plugin_get(self.plugin_name, 'libdir')
@@ -82,22 +115,63 @@ class EditorPlugin(plugin.URLHandler):
                     return os.path.join(dirpath, name)
 
     def get_filepath(self, strmatch):
+        global _git_diff_context
         filepath = None
         line = column = '1'
 
         config = self.config.plugin_get_config(self.plugin_name)
+        git_diff_enabled = config.get('git_diff_support', DEFAULT_GIT_DIFF_SUPPORT)
+        
+        # Git diff processing (only if enabled)
+        if git_diff_enabled:
+            # Always update context for git diff tracking
+            self.update_git_diff_context(strmatch)
+
+            # Special handling for git diff hunk headers (@@ -x,y +a,b @@)
+            # Make these clickable using the cached file from previous --- or +++ line
+            if strmatch.startswith('@@'):
+                hunk_match = re.search(r'@@ -\d+,?\d* \+(\d+)', strmatch)
+                if hunk_match and _git_diff_context.get('file'):
+                    filepath = os.path.join(self.get_cwd(), _git_diff_context['file'])
+                    line = hunk_match.group(1)
+                    return filepath, line, column
+            
+            # Special handling for git diff file headers (matched via lookbehind)
+            # strmatch will be just the filename (e.g., "app-be/composer.json")
+            elif ('/' in strmatch or '.' in strmatch):
+                filepath = os.path.join(self.get_cwd(), strmatch)
+                # Use cached line number if available from previous @@ header
+                if _git_diff_context.get('line'):
+                    line = _git_diff_context['line']
+                return filepath, line, column
+
+        config = self.config.plugin_get_config(self.plugin_name)
         match = re.match(config['match'], strmatch)
-        groups = [group for group in match.groups() if group is not None]
+        if not match:
+            return filepath, line, column
+
+        groups = match.groups()
         group_names = config['groups'].split()
 
         for group_value, group_name in zip(groups, group_names):
+            if group_value is None:
+                continue
+            # Clean up colon prefix from line/column groups
+            if group_value.startswith(':'):
+                group_value = group_value[1:]
+
             if group_name == 'file':
-                filepath = os.path.join(self.get_cwd(), group_value)
-                if not os.path.exists(filepath):
-                    filepath = self.search_filepath_in_libdir(group_value)
-            elif group_name == 'line':
+                # Try absolute path first
+                if os.path.isabs(group_value) and os.path.exists(group_value):
+                    filepath = group_value
+                # Try relative to cwd
+                else:
+                    filepath = os.path.join(self.get_cwd(), group_value)
+                    if not os.path.exists(filepath):
+                        filepath = self.search_filepath_in_libdir(group_value)
+            elif group_name == 'line' and group_value:
                 line = group_value
-            elif group_name == 'column':
+            elif group_name == 'column' and group_value:
                 column = group_value
         return filepath, line, column
 


### PR DESCRIPTION
This patch adds a feature to create links for the following parts of this `git diff` output:
* `--- a/<filename>`
* `+++ b/<filename>`
* `@@ -<line> +<line> @@` (line sensitive link!)

```
diff --git a/README.md b/README.md
index f5e6bcc..f6da1d2 100644
--- a/README.md
+++ b/README.md
@@ -14,9 +14,21 @@ See the demo at https://github.com/mchelem/terminator-editor-plugin/wiki.
```